### PR TITLE
refactor(editor): extract useTextTool (Phase 3b)

### DIFF
--- a/apps/desktop/src/components/EditorOverlay.jsx
+++ b/apps/desktop/src/components/EditorOverlay.jsx
@@ -27,7 +27,7 @@ import StickerPanel from "./editor/StickerPanel";
 import FramePanel from "./editor/FramePanel";
 import FrameStage from "./editor/components/FrameStage";
 import { useFrameTool } from "./editor/state/useFrameTool";
-import { createDefaultLayer, getBgPadding } from "./editor/textState";
+import { getBgPadding } from "./editor/textState";
 import {
   hexToRgba,
   getSourceDimensions,
@@ -47,6 +47,7 @@ import { useEditorImage } from "./editor/state/useEditorImage";
 import { useEditorViewport } from "./editor/state/useEditorViewport";
 import { useEditorSave } from "./editor/state/useEditorSave";
 import { useCropTool } from "./editor/state/useCropTool";
+import { useTextTool } from "./editor/state/useTextTool";
 import { useStickerImageCache } from "./editor/state/useStickerImageCache";
 import { useStickerRegion } from "./editor/state/useStickerRegion";
 import { useDepthModel } from "./editor/state/useDepthModel";
@@ -67,8 +68,6 @@ import {
   isTextLayer,
   isStickerLayer,
   getTextLayers,
-  moveLayerBy,
-  removeLayerById,
 } from "./editor/layerStack";
 
 function clamp(value, min, max) {
@@ -351,8 +350,13 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
   const [compareState, setCompareState] = useState(null); // { afterPath, layout: "side"|"stack" }
   const layerHistory = useLayerHistory();
   const { layers, setLayers, historyRef: layerHistoryRef, indexRef: layerHistoryIndexRef } = layerHistory;
-  const [selectedIds, setSelectedIds] = useState(new Set());
-  const textClipboardRef = useRef(null);
+  // Text tool — selection + clipboard + layer CRUD (destructured with the
+  // original names so call sites are unchanged).
+  const {
+    selectedIds, setSelectedIds,
+    moveLayer: handleMoveLayer, deleteLayer: handleDeleteLayer,
+    addTextLayer, selectLayers, copySelection, pasteClipboard, deleteSelection,
+  } = useTextTool({ layers, layerHistory });
   // Scene-level depth: one Depth Anything V2 inference per source image,
   // cached as both an Image (for visualization) and a Canvas (for pixel reads).
   // RAW originals (.cr3/.3fr/…) can't be decoded by the renderer or sharp, so
@@ -440,18 +444,6 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
     clearSceneDepth();
   }
 
-  function handleMoveLayer(id, direction) {
-    commitLayers(moveLayerBy(layers, id, direction));
-  }
-
-  function handleDeleteLayer(id) {
-    commitLayers(removeLayerById(layers, id));
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-  }
 
   // Thin wrapper around the pure layer renderer that supplies the sticker
   // image cache from our closure.
@@ -696,15 +688,7 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
       // aborts while the preview image is still decoding.
       getPreviewReady: () => previewReadyRef.current,
       getSaving: () => saving,
-      addTextLayer: (text) => {
-        const nl = createDefaultLayer({ text: text || "Test Text", x: 0.5, y: 0.5 });
-        const next = [...layers, nl];
-        commitLayers(next);
-        setSelectedIds(new Set([nl.id]));
-        // Return the post-add count so the test doesn't have to wait for a
-        // React re-render before reading state.
-        return { id: nl.id, count: next.length };
-      },
+      addTextLayer: (text) => addTextLayer(text),
       getLayerCount: () => layers.length,
       getTool: () => tool,
       setTool: (t) => setTool(t),
@@ -729,7 +713,7 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
       setAspect: (key) => commitAspect(key),
       deleteLayer: (id) => handleDeleteLayer(id),
       moveLayer: (id, dir) => handleMoveLayer(id, dir),
-      selectLayers: (ids) => setSelectedIds(new Set(ids)),
+      selectLayers: (ids) => selectLayers(ids),
       undo: () => handleUndo(),
       redo: () => handleRedo(),
       exportFrame: (savePath) => frameToolRef.current?.exportTo?.(savePath),
@@ -823,25 +807,17 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "c" && tool === "text" && selectedIds.size > 0) {
         event.preventDefault();
-        const copied = layers.filter((l) => isTextLayer(l) && selectedIds.has(l.id)).map((l) => ({ ...l }));
-        if (copied.length > 0) textClipboardRef.current = copied;
+        copySelection();
         return;
       }
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "v" && tool === "text" && textClipboardRef.current?.length > 0) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "v" && tool === "text") {
         event.preventDefault();
-        const pasted = textClipboardRef.current.map((l) => {
-          const { id, ...rest } = l;
-          return createDefaultLayer({ ...rest, x: l.x + 0.02, y: l.y + 0.02 });
-        });
-        const currentLayers = layerHistoryRef.current[layerHistoryIndexRef.current] || [];
-        commitLayers([...currentLayers, ...pasted]);
-        setSelectedIds(new Set(pasted.map((p) => p.id)));
+        pasteClipboard();
         return;
       }
       if ((event.key === "Delete" || event.key === "Backspace") && tool === "text" && selectedIds.size > 0) {
         event.preventDefault();
-        commitLayers(layers.filter((l) => !selectedIds.has(l.id)));
-        setSelectedIds(new Set());
+        deleteSelection();
         return;
       }
       if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.shiftKey) {

--- a/apps/desktop/src/components/editor/state/useTextTool.js
+++ b/apps/desktop/src/components/editor/state/useTextTool.js
@@ -1,0 +1,77 @@
+// Text tool — selection + clipboard + layer CRUD actions. Owns which layers are
+// selected and the copy/paste clipboard; the layer STACK itself lives in
+// useLayerHistory. Extracted from EditorOverlay (Phase 3b).
+//
+// The heavier "Apply text" bake (composite onto the source + reset the editor)
+// stays in EditorOverlay — like the crop Apply, it's a cross-cutting operation,
+// not tool-local state.
+
+import { useRef, useState } from "react";
+import { createDefaultLayer } from "../textState";
+import { isTextLayer, moveLayerBy, removeLayerById } from "../layerStack";
+
+export function useTextTool({ layers, layerHistory }) {
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const clipboardRef = useRef(null);
+  const commit = layerHistory.commit;
+
+  function moveLayer(id, direction) {
+    commit(moveLayerBy(layers, id, direction));
+  }
+
+  function deleteLayer(id) {
+    commit(removeLayerById(layers, id));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }
+
+  function selectLayers(ids) {
+    setSelectedIds(new Set(ids));
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+  }
+
+  function addTextLayer(text) {
+    const nl = createDefaultLayer({ text: text || "Test Text", x: 0.5, y: 0.5 });
+    const next = [...layers, nl];
+    commit(next);
+    setSelectedIds(new Set([nl.id]));
+    // Post-add count so callers (e2e) don't wait for a re-render.
+    return { id: nl.id, count: next.length };
+  }
+
+  function copySelection() {
+    const copied = layers.filter((l) => isTextLayer(l) && selectedIds.has(l.id)).map((l) => ({ ...l }));
+    if (copied.length > 0) clipboardRef.current = copied;
+  }
+
+  function pasteClipboard() {
+    if (!clipboardRef.current?.length) return;
+    const pasted = clipboardRef.current.map((l) => {
+      const { id, ...rest } = l;
+      return createDefaultLayer({ ...rest, x: l.x + 0.02, y: l.y + 0.02 });
+    });
+    // Read the live layer stack from history (not the possibly-stale `layers`
+    // closure) so rapid paste after another mutation doesn't clobber it.
+    const currentLayers = layerHistory.historyRef.current[layerHistory.indexRef.current] || [];
+    commit([...currentLayers, ...pasted]);
+    setSelectedIds(new Set(pasted.map((p) => p.id)));
+  }
+
+  function deleteSelection() {
+    if (selectedIds.size === 0) return;
+    commit(layers.filter((l) => !selectedIds.has(l.id)));
+    setSelectedIds(new Set());
+  }
+
+  return {
+    selectedIds, setSelectedIds,
+    moveLayer, deleteLayer, selectLayers, clearSelection, addTextLayer,
+    copySelection, pasteClipboard, deleteSelection,
+  };
+}


### PR DESCRIPTION
## Phase 3b of the EditorOverlay decomposition

Extracts the **text tool's** bounded state into `useTextTool` — the fourth per-tool hook after `useCropTool` (3a), following the plan in `docs/editoroverlay-refactor-plan.md`.

### What moved
- `selectedIds` (layer selection) + the copy/paste `clipboardRef`
- Layer CRUD/selection actions: `moveLayer`, `deleteLayer`, `selectLayers`, `clearSelection`, `addTextLayer`, `copySelection`, `pasteClipboard`, `deleteSelection`

### What stayed (deliberately)
- The layer **stack** itself — still `useLayerHistory`.
- `handleTextApply` / `drawTextLayersOnCanvas` — cross-cutting "bake onto source" + shared with the save path, parallel to how crop's `handleApply` was left in Phase 3a.

### Invariants preserved
- EditorOverlay destructures with the **original names** (`handleMoveLayer`, `handleDeleteLayer`, `selectedIds`, …) → call sites unchanged.
- Paste reads the **live** layer stack from `layerHistory.historyRef.current[indexRef.current]`, not the stale `layers` closure (the rapid-paste race fix).
- E2E backdoor (`addTextLayer`/`selectLayers`/`deleteLayer`/`moveLayer`) now delegates to the hook.

### Verification
- `npm run build` ✅
- Golden e2e `03 / 06 / 18 / 19 / 20` — **18 passed**.

EditorOverlay: 1218 → 1194 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)