### PR TITLE
refactor(editor): extract useStickerTool (Phase 3c)

### DIFF
--- a/apps/desktop/src/components/EditorOverlay.jsx
+++ b/apps/desktop/src/components/EditorOverlay.jsx
@@ -48,8 +48,7 @@ import { useEditorViewport } from "./editor/state/useEditorViewport";
 import { useEditorSave } from "./editor/state/useEditorSave";
 import { useCropTool } from "./editor/state/useCropTool";
 import { useTextTool } from "./editor/state/useTextTool";
-import { useStickerImageCache } from "./editor/state/useStickerImageCache";
-import { useStickerRegion } from "./editor/state/useStickerRegion";
+import { useStickerTool } from "./editor/state/useStickerTool";
 import { useDepthModel } from "./editor/state/useDepthModel";
 import { useLayerHistory } from "./editor/state/useLayerHistory";
 import { useSceneDepth } from "./editor/state/useSceneDepth";
@@ -393,8 +392,10 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
   const handleComputeDepth = depth.compute;
   const handleClearDepth = depth.clearAll;
 
-  const stickerImageCache = useStickerImageCache(layers);
-  const sticker = useStickerRegion(item?.asset_id);
+  const { imageCache: stickerImageCache, region: sticker } = useStickerTool({
+    layers,
+    assetId: item?.asset_id,
+  });
 
   const { depthModel, pickDepthModel: handlePickDepthModel, resetDepthModel: handleResetDepthModel } =
     useDepthModel({

--- a/apps/desktop/src/components/editor/state/useStickerTool.js
+++ b/apps/desktop/src/components/editor/state/useStickerTool.js
@@ -1,0 +1,18 @@
+// Sticker tool — thin composition of the two pre-existing sticker hooks so the
+// editor wires up one call, consistent with useCropTool / useTextTool. Extracted
+// from EditorOverlay (Phase 3c).
+//
+// - `imageCache`: decoded sticker images keyed off the current layer stack
+//   (useStickerImageCache), consumed by the layer renderer.
+// - `region`: the drag-to-draw marquee that limits subject detection, scoped to
+//   the current asset (useStickerRegion) — exposes { region, drag, setDrag,
+//   commit, clear }.
+
+import { useStickerImageCache } from "./useStickerImageCache";
+import { useStickerRegion } from "./useStickerRegion";
+
+export function useStickerTool({ layers, assetId }) {
+  const imageCache = useStickerImageCache(layers);
+  const region = useStickerRegion(assetId);
+  return { imageCache, region };
+}


### PR DESCRIPTION
## Phase 3c of the EditorOverlay decomposition

The sticker tool was already thin — `useStickerImageCache` and `useStickerRegion` are pre-existing hooks. This phase just **composes** them behind one `useStickerTool({ layers, assetId })` call so the editor wires up sticker state the same way it does crop (3a) and text (3b).

### What moved
- Two hook calls (`useStickerImageCache(layers)` + `useStickerRegion(item?.asset_id)`) collapse into one `useStickerTool` call.

### Invariants preserved
- EditorOverlay destructures with the **original names** (`stickerImageCache`, `sticker`) → every downstream call site (`sticker.region` / `.drag` / `.setDrag` / `.commit` / `.clear`, the `drawLayersOnCanvas` cache, `StickerRegionOverlay`, `StickerPanel`) is unchanged.

### Verification
- `npm run build` ✅
- Golden e2e `03 / 04 / 06 / 18 / 19 / 20` — **23 passed** (04 is the sticker create/detect spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)