### PR TITLE
test(e2e): de-flake 02-navigation Rated filter assertion

### DIFF
--- a/apps/desktop/e2e/02-navigation.spec.js
+++ b/apps/desktop/e2e/02-navigation.spec.js
@@ -49,7 +49,13 @@ test.describe("Sidebar navigation", () => {
     const rated = window.getByRole("button", { name: /Rated/i }).first();
     await expect(rated).toBeVisible();
     await rated.click();
-    await expect(window.locator("[data-gallery-item='true']")).toHaveCount(4, { timeout: 5_000 });
+    // Wait for the filtered gallery to actually re-query and paint before
+    // counting — under full-suite contention the re-query can take several
+    // seconds, and a bare toHaveCount raced an empty (0-item) intermediate
+    // state. Anchor on "at least one item visible" first, then assert exactly
+    // the four rated assets.
+    await expect(window.locator("[data-gallery-item='true']").first()).toBeVisible({ timeout: 10_000 });
+    await expect(window.locator("[data-gallery-item='true']")).toHaveCount(4, { timeout: 10_000 });
 
     // restore
     await window.getByRole("button", { name: /All Assets/i }).first().click();


### PR DESCRIPTION
## Problem

`02-navigation › Recently Added and Rated filters load real data` intermittently failed in the **full suite** (`toHaveCount` got `0`, expected `4`) but passed in isolation. It's a timing race, not a logic bug: after clicking **Rated**, the gallery re-queries, and under full-suite contention (many sequential Electron launches) that re-query can take several seconds. The bare `toHaveCount(4, { timeout: 5_000 })` polled the empty intermediate state for the whole 5s and gave up.

## Fix

Anchor on "at least one item visible" (10s) *before* counting, then assert exactly 4 (10s) — mirroring the Recently-Added wait immediately above it in the same test.

```js
await rated.click();
await expect(gallery.first()).toBeVisible({ timeout: 10_000 }); // wait for re-query to paint
await expect(gallery).toHaveCount(4, { timeout: 10_000 });      // then the exact count
```

## Verification

Full `npm run e2e`: **76 passed, 8 skipped, 0 failed** (the 8 skips are intentional environment gates — VisionKit/CoreML needing macOS+Xcode toolchain in `04-sticker`/`07-depth`, no external editor in `16-open-with`, and the `DEMO=1`-gated `demo.spec.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)