### PR TITLE
chore(release): v0.3.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afterframe",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "description": "AfterFrame desktop shell",
   "author": "YI WANG",


### PR DESCRIPTION
Patch release **v0.3.3** — bumps `apps/desktop/package.json` 0.3.2 → 0.3.3.

### What ships since v0.3.2
- **Brand watermark frames** — new editor tool: 20+ presets, per-brand logos & colors (Canon red, Sony α orange, Nikon/Leica/Fujifilm/Lumix/Ricoh…), vertical side-strip layouts, logo color picker (原色/黑/白/灰/金), original-resolution export.
- **Watched directories** — auto-import new files from watched folders (FSEvents + cheap startup catch-up), delete-protection / delete-from-disk.
- **Open in external editor** — right-click to open in Photoshop / Lightroom (nested-bundle detection).
- **Lightbox** — zoom-slider thumb fixes, Esc closes with slider focused, fixed-width zoom %.
- **Internal** — EditorOverlay decomposed into per-tool hooks (image/history/viewport/save/crop/text/sticker) + shell components (Header/ToolRail/PanelChrome/CropPanel); golden e2e safety net; de-flaked nav spec. 1713 → 986 lines, behavior-preserving.

DMG is built + attached to the GitHub Release after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)