### PR TITLE
docs: restore stranded README fix (EN color list + zh Frame section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The core of AfterFrame — a catalog-based workflow that keeps your originals on
 
 ![Collage](docs/assets/collage.png)
 
-- **Frame** — brand-aware camera watermark frames driven by EXIF. Pick from 20+ presets (bottom bars, dual-logo, and vertical side-strip layouts), rendered with real brand logos and colors for Hasselblad, Sony, Canon, Nikon, Leica, Fujifilm, Lumix, and Ricoh, plus a clean generic set. Adaptive light/dark contrast, a logo color picker (原色 / black / white / grey / gold), text and margin scaling, and export at the original resolution
+- **Frame** — brand-aware camera watermark frames driven by EXIF. Pick from 20+ presets (bottom bars, dual-logo, and vertical side-strip layouts), rendered with real brand logos and colors for Hasselblad, Sony, Canon, Nikon, Leica, Fujifilm, Lumix, and Ricoh, plus a clean generic set. Adaptive light/dark contrast, a logo color picker (original / black / white / grey / gold), text and margin scaling, and export at the original resolution
 
 ![Frame — Hasselblad wordmark](docs/assets/frame-hasselblad.png)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,6 +86,14 @@ AfterFrame 的核心 —— 基于 Catalog 的工作流，原图始终留在硬�
 
 ![拼图](docs/assets/collage.png)
 
+- **相框**：由 EXIF 驱动的品牌相机水印相框。提供 20+ 预设（底栏、双 logo、竖排侧边条），以哈苏、索尼、佳能、尼康、徕卡、富士、松下 Lumix、理光的真实品牌 logo 与配色渲染，另有一套简洁通用版。自适应明暗对比、logo 颜色选择（原色 / 黑 / 白 / 灰 / 金）、文字与留白缩放，并可按原图分辨率导出
+
+![相框 · 哈苏字标](docs/assets/frame-hasselblad.png)
+
+![相框 · 索尼底栏](docs/assets/frame-sony.png)
+
+![相框 · 品牌预设](docs/assets/frame-presets.png)
+
 ### 视频
 - 视频与照片一同索引 —— 导入时探测时长、分辨率与编码，并自动生成封面帧
 - 画廊卡片显示封面与时长徽章；鼠标悬停即可在关键帧胶片条上拖动预览，无需打开


### PR DESCRIPTION
PR #14 merged only its first commit — the follow-up fix (`e3cf001`) was left behind on the branch, so `main` still has:

- **EN README**: `logo color picker (原色 / black / white / grey / gold)` — the mixed-language list.
- **ZH README**: no 相框 (Frame) section at all.

This re-applies that stranded commit onto current main:
- `README.md`: `原色` → `original` (all-English list).
- `README.zh-CN.md`: adds the matching 相框 section + the three screenshots, color picker as 原色 / 黑 / 白 / 灰 / 金.

🤖 Generated with [Claude Code](https://claude.com/claude-code)