### PR TITLE
feat(frame): pad framed export to a target aspect ratio

### DIFF
--- a/apps/desktop/e2e/20-frame.spec.js
+++ b/apps/desktop/e2e/20-frame.spec.js
@@ -70,4 +70,23 @@ test.describe("Golden: frame export", () => {
     expect(dims.width).toBe(m.width);
     expect(dims.height).toBe(m.height);
   });
+
+  test("aspect option pads the export to the chosen ratio (1:1), still full-res", async () => {
+    await window.evaluate(() => window.__afterframeTest.setFrameAspect("1:1"));
+    await window.waitForTimeout(500); // let the ref pick up the new aspect
+
+    const outPath = path.join(tmp, "framed-1x1.jpg");
+    const dims = await window.evaluate((p) => window.__afterframeTest.exportFrame(p), outPath);
+    const m = await sharp(outPath).metadata();
+
+    // square within rounding tolerance
+    expect(Math.abs(m.width / m.height - 1)).toBeLessThan(0.01);
+    // landscape source → padding is added to HEIGHT, so width stays the full-res
+    // source width (proves it didn't fall back to the 2200px preview).
+    expect(m.width).toBe(SRC_W);
+    expect(dims.width).toBe(m.width);
+    expect(dims.height).toBe(m.height);
+
+    await window.evaluate(() => window.__afterframeTest.setFrameAspect("free")); // restore
+  });
 });

--- a/apps/desktop/src/components/EditorOverlay.jsx
+++ b/apps/desktop/src/components/EditorOverlay.jsx
@@ -612,13 +612,14 @@ export default function EditorOverlay({ open, item, onClose, onSaveComplete, pus
       undo: () => handleUndo(),
       redo: () => handleRedo(),
       exportFrame: (savePath) => frameToolRef.current?.exportTo?.(savePath),
+      setFrameAspect: (key) => frameToolRef.current?.setFrameAspectKey?.(key),
     };
     return () => {
       if (window.__afterframeTest) {
         for (const k of [
           "saveAs", "getPreviewReady", "getSaving", "addTextLayer", "getLayerCount",
           "getTool", "setTool", "getState", "setAspect", "deleteLayer", "moveLayer",
-          "selectLayers", "undo", "redo", "exportFrame",
+          "selectLayers", "undo", "redo", "exportFrame", "setFrameAspect",
         ]) delete window.__afterframeTest[k];
       }
     };

--- a/apps/desktop/src/components/editor/FramePanel.jsx
+++ b/apps/desktop/src/components/editor/FramePanel.jsx
@@ -3,6 +3,13 @@
 
 import { Download, LoaderCircle } from "lucide-react";
 import { SliderRow } from "../../ui";
+import { ASPECT_PRESETS } from "./cropMath";
+
+// Same ratio set as the Crop tool, so a framed export can be padded to a common
+// aspect. "free" keeps the frame's natural size; "original" targets the photo's
+// own ratio. Labels localized for this (Chinese) panel.
+const FRAME_ASPECT_LABELS = { free: "自由", original: "原图" };
+const FRAME_ASPECTS = ASPECT_PRESETS.map((p) => ({ key: p.key, label: FRAME_ASPECT_LABELS[p.key] || p.label }));
 
 // Logo tint choices. `value: null` = 原色 (brand color where iconic, else
 // frame-appropriate mono). Others force that color on the mark.
@@ -16,7 +23,8 @@ const LOGO_COLORS = [
 
 export default function FramePanel({ frameTool }) {
   const { templates, templateId, setTemplateId, thumbs, cellAspect, logosReady, exporting, rendering, exportFramed,
-    textScale, setTextScale, marginScale, setMarginScale, logoColor, setLogoColor } = frameTool;
+    textScale, setTextScale, marginScale, setMarginScale, logoColor, setLogoColor,
+    frameAspectKey, setFrameAspectKey } = frameTool;
   return (
     <div className="flex max-h-[calc(100vh-10rem)] flex-col">
       <div className="flex-1 overflow-y-auto px-3 py-3">
@@ -49,6 +57,25 @@ export default function FramePanel({ frameTool }) {
         {!logosReady && <div className="mt-3 px-1 text-[11px] text-muted2">正在加载 logo…</div>}
       </div>
       <div className="border-t border-border/60 px-3 py-3">
+        <div className="mb-3.5 flex items-start gap-2">
+          <span className="min-w-[48px] pt-1 text-[10px] text-muted2">比例</span>
+          <div className="flex flex-1 flex-wrap gap-1.5">
+            {FRAME_ASPECTS.map((a) => {
+              const active = a.key === frameAspectKey;
+              return (
+                <button
+                  key={a.key} type="button" title={a.label}
+                  onClick={() => setFrameAspectKey(a.key)}
+                  className={`rounded px-2 py-1 text-[10.5px] leading-none transition ${
+                    active ? "bg-[rgb(var(--accent-color)/0.18)] text-[rgb(var(--accent-color))]" : "bg-app text-muted hover:bg-hover hover:text-text"
+                  }`}
+                >
+                  {a.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
         <div className="mb-3.5 flex items-center gap-2">
           <span className="min-w-[48px] text-[10px] text-muted2">标志</span>
           <div className="flex items-center gap-2">

--- a/apps/desktop/src/components/editor/render/frameRender.js
+++ b/apps/desktop/src/components/editor/render/frameRender.js
@@ -201,7 +201,7 @@ function sampleLuminance(ctx, cx, cy, w, h) {
  * @param {Map<string, HTMLImageElement>} [args.logoImages] key -> tinted image
  * @returns {HTMLCanvasElement}
  */
-export function renderFrame({ photo, exif = {}, profile = {}, template, registry, logoImages = new Map(), adjust, logoColor }) {
+export function renderFrame({ photo, exif = {}, profile = {}, template, registry, logoImages = new Map(), adjust, logoColor, frameAspect = null }) {
   const adj = { text: adjust?.text ?? 1, margin: adjust?.margin ?? 1 };
   const g = geometry(photo, template, adj);
   const { wref, padPx, outW, outH } = g;
@@ -372,5 +372,29 @@ export function renderFrame({ photo, exif = {}, profile = {}, template, registry
   }
 
   drawLayersOnCanvas(ctx, outW, outH, layers, logoImages);
+
+  // Optional: pad the finished frame out to a target aspect ratio (e.g. 3:4,
+  // 16:9) so the export matches a common ratio. The whole framed unit is
+  // centered on a larger background-colored canvas — nothing inside is
+  // distorted or cropped, we only add margin in the frame's own background.
+  if (frameAspect && frameAspect > 0) {
+    const cur = outW / outH;
+    let finalW = outW;
+    let finalH = outH;
+    if (cur < frameAspect) finalW = Math.round(outH * frameAspect); // too tall → widen
+    else finalH = Math.round(outW / frameAspect); // too wide → heighten
+    if (finalW > outW || finalH > outH) {
+      const padded = document.createElement("canvas");
+      padded.width = finalW;
+      padded.height = finalH;
+      const pctx = padded.getContext("2d");
+      pctx.imageSmoothingEnabled = true;
+      pctx.imageSmoothingQuality = "high";
+      pctx.fillStyle = template.canvas?.bg?.color || "#ffffff";
+      pctx.fillRect(0, 0, finalW, finalH);
+      pctx.drawImage(canvas, Math.round((finalW - outW) / 2), Math.round((finalH - outH) / 2));
+      return padded;
+    }
+  }
   return canvas;
 }

--- a/apps/desktop/src/components/editor/state/useFrameTool.js
+++ b/apps/desktop/src/components/editor/state/useFrameTool.js
@@ -8,6 +8,7 @@ import { FRAME_TEMPLATES } from "../frameTemplates";
 import { buildLogoRegistry, prepareLogo } from "../render/frameLogos";
 import { renderFrame, collectLogoNeeds } from "../render/frameRender";
 import { buildTransformedCanvas, getSourceDimensions } from "../render/canvasHelpers";
+import { getAspectRatio } from "../cropMath";
 
 // EXIF lives in nested image_metadata / raw_metadata (same shape the Inspector
 // reads), NOT flat fields. Prefer RAW metadata when it carries the capture.
@@ -71,6 +72,7 @@ export function useFrameTool({ active, item, transformedPreview, sourceImage, ro
   const [textScale, setTextScale] = useState(1); // "文字大小" knob
   const [marginScale, setMarginScale] = useState(1); // "留白" knob
   const [logoColor, setLogoColor] = useState(null); // logo tint override; null = 原色 (auto)
+  const [frameAspectKey, setFrameAspectKey] = useState("free"); // pad output to a target ratio; "free" = frame's natural size
   const logoCacheRef = useRef(new Map());
 
   const template = useMemo(() => FRAME_TEMPLATES.find((t) => t.id === templateId), [templateId]);
@@ -101,7 +103,8 @@ export function useFrameTool({ active, item, transformedPreview, sourceImage, ro
 
   function compose() {
     const base = buildBaseCanvas(transformedPreview, normalizedCrop);
-    return renderFrame({ photo: base, exif, profile: {}, template, registry: logos.registry, logoImages: logoCacheRef.current, adjust, logoColor });
+    const frameAspect = getAspectRatio(frameAspectKey, base.width / base.height);
+    return renderFrame({ photo: base, exif, profile: {}, template, registry: logos.registry, logoImages: logoCacheRef.current, adjust, logoColor, frameAspect });
   }
 
   // Live preview: re-render when active / photo / crop / template / logos / knobs change.
@@ -116,7 +119,7 @@ export function useFrameTool({ active, item, transformedPreview, sourceImage, ro
       setRendering(false);
     })();
     return () => { alive = false; };
-  }, [active, transformedPreview, logos, templateId, cropKey, exifKey, textScale, marginScale, logoColor]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [active, transformedPreview, logos, templateId, cropKey, exifKey, textScale, marginScale, logoColor, frameAspectKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Small framed previews of every template, so the panel shows what each looks
   // like (logo included) instead of a bare name list.
@@ -163,7 +166,8 @@ export function useFrameTool({ active, item, transformedPreview, sourceImage, ro
   async function exportTo(savePath) {
     const base = buildExportBase();
     await ensureLogos(template, base.height || 1200, logoColor);
-    const out = renderFrame({ photo: base, exif, profile: {}, template, registry: logos.registry, logoImages: logoCacheRef.current, adjust, logoColor });
+    const frameAspect = getAspectRatio(frameAspectKey, base.width / base.height);
+    const out = renderFrame({ photo: base, exif, profile: {}, template, registry: logos.registry, logoImages: logoCacheRef.current, adjust, logoColor, frameAspect });
     const blob = await new Promise((res) => out.toBlob(res, "image/jpeg", 0.92));
     await window.mediaWorkspace?.saveImage?.(savePath, await blob.arrayBuffer(), saveBasePath);
     return { width: out.width, height: out.height };
@@ -195,6 +199,7 @@ export function useFrameTool({ active, item, transformedPreview, sourceImage, ro
     framedCanvas, thumbs, cellAspect, rendering, exporting,
     textScale, setTextScale, marginScale, setMarginScale,
     logoColor, setLogoColor,
+    frameAspectKey, setFrameAspectKey,
     logosReady: !!logos,
     exportFramed,
     exportTo, // e2e: export to a given path, skipping the native dialog


### PR DESCRIPTION
## What
Adds a **比例 (aspect ratio)** option to the Frame tool so the finished, framed image can be padded out to a common ratio — the **same preset set as Crop**: 1:1, 3:2 / 2:3, 4:3 / 3:4, 5:4 / 4:5, 16:9 / 9:16, 2.35:1, plus 原图 (photo's own ratio) and 自由 (free).

Requested for social exports (3:4, 16:9, both orientations) that need a fixed frame ratio.

## How
Non-destructive. `renderFrame` builds the framed unit exactly as before; when an aspect is chosen it then **centers that unit on a larger canvas filled with the frame's own background color**, padding only the deficient dimension. Nothing inside the frame is stretched or cropped — you just get letterbox/pillarbox margin in the same color as the frame border.

```
cur = outW/outH
cur < target → widen  (finalW = outH * target)
cur ≥ target → heighten (finalH = outW / target)
```

Applies to both the **live preview** and the **full-res export**. Default is 自由 → identical output to before.

## Files
- `render/frameRender.js` — `frameAspect` param + center-on-padded-canvas wrap
- `state/useFrameTool.js` — `frameAspectKey` state, resolved via `getAspectRatio`, threaded into `compose()` + `exportTo()`
- `FramePanel.jsx` — 比例 chip row (reuses `ASPECT_PRESETS`)
- `EditorOverlay.jsx` — `setFrameAspect` e2e backdoor
- `e2e/20-frame.spec.js` — new test: 1:1 export is square **and** still full-res (3000px)

## Verification
- `npm run build` ✅
- Golden e2e `03 / 06 / 20` — **all pass**; the new aspect test confirms a landscape source padded to 1:1 is square and keeps the full-res width (not the 2200px preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)