### PR TITLE
harden: disable external XML entity processing in metadata.py...

### DIFF
--- a/services/sidecar/pyproject.toml
+++ b/services/sidecar/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "pillow-heif>=0.16",
     # Batched cosine clustering for local face embeddings.
     "numpy>=1.26,<3",
+    # Safe XML parsing (guards against XXE) for embedded XMP metadata.
+    "defusedxml>=0.7",
 ]
 
 [project.optional-dependencies]

--- a/services/sidecar/src/media_workspace/metadata.py
+++ b/services/sidecar/src/media_workspace/metadata.py
@@ -4,7 +4,7 @@ import hashlib
 import os
 import re
 import struct
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from collections.abc import Sequence
 from datetime import UTC, datetime
 from io import BytesIO
@@ -88,7 +88,7 @@ def quick_fingerprint_from_handle(
 ) -> str:
     if mode not in FINGERPRINT_MODES:
         raise ValueError(f"unsupported fingerprint mode: {mode}")
-    sha1 = hashlib.sha1()
+    sha1 = hashlib.sha1(usedforsecurity=False)
     start = head_bytes[:chunk_size] if head_bytes is not None else handle.read(chunk_size)
     sha1.update(start)
     if mode == "head-tail" and file_size > chunk_size:


### PR DESCRIPTION
## Summary
Harden input handling in `services/sidecar/src/media_workspace/metadata.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `gitlab.bandit.B313.B314.B315.B316.B318.B319.B320.B405.B406.B407.B408.B409.B410` |
| **File** | `services/sidecar/src/media_workspace/metadata.py:7` |
| **Assessment** | Defensive hardening |

**Description**: Found use of the native Python XML libraries, which is vulnerable to XML external entity (XXE)
attacks. The Python documentation recommends the 'defusedxml' library instead. Use 'defusedxml'.
See https://github.com/tiran/defusedxml for more information.


## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `services/sidecar/pyproject.toml`
- `services/sidecar/src/media_workspace/metadata.py`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
