### PR TITLE
Bump AfterFrame to 0.5.0

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "afterframe",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "afterframe",
-      "version": "0.4.7",
+      "version": "0.5.0",
       "dependencies": {
         "@fontsource/caveat": "^5.2.8",
         "@fontsource/inter": "^5.2.8",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afterframe",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "private": true,
   "description": "AfterFrame desktop shell",
   "author": "YI WANG",


### PR DESCRIPTION
Update the desktop app version from 0.4.7 to 0.5.0 in package.json and both root lockfile entries. Verified that all three version values agree and git diff --check passes. No runtime code or dependency changes.