### PR TITLE
Add folder drag ordering and filter macOS metadata files

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -80,3 +80,4 @@ jobs:
           e2e/19-editor-layers.spec.js
           e2e/20-frame.spec.js
           e2e/21-canvas-pad.spec.js
+          e2e/29-folder-order.spec.js

--- a/apps/desktop/e2e-web/01-web-smoke.spec.js
+++ b/apps/desktop/e2e-web/01-web-smoke.spec.js
@@ -139,3 +139,11 @@ test("byte limit rejects a batch without decoding originals", async ({ page }) =
   expect(result).toContain("200 MB");
   expect(await page.evaluate(() => indexedDB.databases())).toEqual([]);
 });
+
+
+test("ignores macOS metadata companions during browser import", async ({ page }) => {
+  await dropFiles(page, [FIXTURE, FIXTURE], { names: ["portrait.jpg", "._portrait.jpg"] });
+  await expect(card(page, "portrait")).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator('[data-gallery-item="true"]')).toHaveCount(1);
+  await expect(card(page, "._portrait")).toHaveCount(0);
+});

--- a/apps/desktop/e2e-web/02-folder-order.spec.js
+++ b/apps/desktop/e2e-web/02-folder-order.spec.js
@@ -1,0 +1,9 @@
+const { test, expect } = require('@playwright/test');
+const { exerciseFolderOrder } = require('../e2e/helpers/folder-order');
+
+test('browser folders reorder in both views without interfering with photo drops', async ({ page }) => {
+  await page.goto('/web.html');
+  await page.getByRole('button', { name: 'Browse Sample Library' }).click();
+  await expect(page.locator('[data-gallery-item="true"]').first()).toBeVisible({ timeout: 15000 });
+  await exerciseFolderOrder(page);
+});

--- a/apps/desktop/e2e/29-folder-order.spec.js
+++ b/apps/desktop/e2e/29-folder-order.spec.js
@@ -1,0 +1,13 @@
+const { test, expect } = require('@playwright/test');
+const { launchApp, closeApp } = require('./helpers/app');
+const { exerciseFolderOrder } = require('./helpers/folder-order');
+
+test('folder drag ordering persists and remains separate from photo drops', async () => {
+  const { app, window, userDataDir } = await launchApp({ testName: 'folder-order' });
+  try {
+    await expect(window.locator('[data-gallery-item="true"]').first()).toBeVisible({ timeout: 15000 });
+    await exerciseFolderOrder(window, { reload: true });
+  } finally {
+    await closeApp(app, userDataDir);
+  }
+});

--- a/apps/desktop/e2e/helpers/folder-order.js
+++ b/apps/desktop/e2e/helpers/folder-order.js
@@ -1,0 +1,65 @@
+const { expect } = require('@playwright/test');
+
+async function exerciseFolderOrder(page, { reload = false } = {}) {
+  const scroll = page.getByTestId('sidebar-folder-scroll');
+  for (const name of ['Order Zulu', 'Order Alpha', 'Order Middle']) {
+    await page.getByTitle('New folder', { exact: true }).click();
+    await scroll.locator('input').fill(name);
+    await scroll.locator('input').press('Enter');
+    await expect(scroll.locator('[data-collection-id]').filter({ hasText: name })).toBeVisible();
+  }
+  const row = (name) => scroll.locator('[data-collection-id]').filter({ hasText: name });
+  const ids = await scroll.locator('[data-collection-id]').evaluateAll((rows) => rows.map((r) => r.dataset.collectionId));
+  const sourceId = await row('Order Middle').getAttribute('data-collection-id');
+  const targetId = await row('Order Zulu').getAttribute('data-collection-id');
+  const expected = ids.filter((id) => id !== sourceId);
+  expected.splice(expected.indexOf(targetId), 0, sourceId);
+  const order = () => scroll.locator('[data-collection-id]').evaluateAll((rows) => rows.map((r) => r.dataset.collectionId));
+  await row('Order Middle').dragTo(row('Order Zulu'), { targetPosition: { x: 20, y: 2 } });
+  await expect.poll(order).toEqual(expected);
+  await expect(row('Order Middle')).toHaveAttribute('draggable', 'true');
+  if (reload) {
+    await page.reload();
+    await expect.poll(order).toEqual(expected);
+  }
+  await page.getByTitle('Show covers', { exact: true }).click();
+  const box = await row('Order Alpha').boundingBox();
+  await row('Order Middle').dragTo(row('Order Alpha'), { targetPosition: { x: 20, y: box.height - 2 } });
+  const final = expected.filter((id) => id !== sourceId);
+  const alphaId = await row('Order Alpha').getAttribute('data-collection-id');
+  final.splice(final.indexOf(alphaId) + 1, 0, sourceId);
+  await expect.poll(order).toEqual(final);
+  await expect(row('Order Middle')).toHaveAttribute('draggable', 'true');
+  // Cancelling a drag removes the marker without changing saved order.
+  const transfer = await page.evaluateHandle(() => new DataTransfer());
+  await row('Order Middle').dispatchEvent('dragstart', { dataTransfer: transfer });
+  const targetBox = await row('Order Zulu').boundingBox();
+  await row('Order Zulu').dispatchEvent('dragover', { dataTransfer: transfer, clientY: targetBox.y + 1 });
+  await expect(row('Order Zulu')).toHaveAttribute('data-folder-insertion', 'before');
+  await row('Order Middle').dispatchEvent('dragend', { dataTransfer: transfer });
+  await transfer.dispose();
+  await expect(scroll.locator('[data-folder-insertion]')).toHaveCount(0);
+  await expect.poll(order).toEqual(final);
+  // Moving a photo must add membership, never reorder the folder list.
+  const card = page.locator('[data-gallery-item="true"]').first();
+  if (reload) {
+    // Electron hands photo drags to macOS; dispatch its DOM payload here so
+    // the test does not enter a native drag loop outside Playwright's control.
+    const assetId = await card.getAttribute('data-asset-id');
+    const transfer = await page.evaluateHandle((id) => {
+      const data = new DataTransfer();
+      data.setData('application/x-media-workspace-asset', JSON.stringify({ assetIds: [id] }));
+      return data;
+    }, assetId);
+    await row('Order Alpha').dispatchEvent('dragover', { dataTransfer: transfer });
+    await expect(row('Order Alpha')).toHaveClass(/ring-inset/);
+    await row('Order Alpha').dispatchEvent('drop', { dataTransfer: transfer });
+    await transfer.dispose();
+  } else {
+    await card.dragTo(row('Order Alpha'));
+  }
+  await expect(row('Order Alpha')).toContainText('1 item');
+  await expect.poll(order).toEqual(final);
+  await expect(scroll.locator('[data-folder-insertion]')).toHaveCount(0);
+}
+module.exports = { exerciseFolderOrder };

--- a/apps/desktop/electron/ipc/collections.js
+++ b/apps/desktop/electron/ipc/collections.js
@@ -14,6 +14,10 @@ function register({ ipcMain, commands, getCatalogState }) {
     }
   });
 
+  ipcMain.handle("workspace:reorder-collections", async (_event, collectionIds) => {
+    return await commands.reorderCollections(collectionIds);
+  });
+
   ipcMain.handle("workspace:create-collection", async (_event, name, kind) => {
     return await commands.createCollection(name, kind || "manual");
   });

--- a/apps/desktop/electron/preload.js
+++ b/apps/desktop/electron/preload.js
@@ -144,6 +144,7 @@ contextBridge.exposeInMainWorld("mediaWorkspace", {
   listRepaintHistory: (assetPath) => ipcRenderer.invoke("workspace:list-repaint-history", assetPath),
   getAiStyles: () => ipcRenderer.invoke("workspace:get-ai-styles"),
   saveAiStyles: (styles) => ipcRenderer.invoke("workspace:save-ai-styles", styles),
+  reorderCollections: (collectionIds) => ipcRenderer.invoke("workspace:reorder-collections", collectionIds),
   listCollections: () => ipcRenderer.invoke("workspace:list-collections"),
   createCollection: (name, kind) => ipcRenderer.invoke("workspace:create-collection", name, kind),
   updateCollection: (collectionId, updates) => ipcRenderer.invoke("workspace:update-collection", collectionId, updates),

--- a/apps/desktop/electron/sidecar/commands.js
+++ b/apps/desktop/electron/sidecar/commands.js
@@ -214,6 +214,10 @@ function createSidecarCommands(callJson) {
       return callJson(["list-collections"]).then((rows) => rows || []);
     },
 
+    reorderCollections(collectionIds) {
+      return callJson(["reorder-collections", ...collectionIds.flatMap((id) => ["--collection-id", String(id)])]);
+    },
+
     createCollection(name, kind = "manual") {
       return callJson(["create-collection", "--name", String(name), "--kind", String(kind)]);
     },

--- a/apps/desktop/src/App.jsx
+++ b/apps/desktop/src/App.jsx
@@ -1031,6 +1031,8 @@ export default function App() {
           }}
           onClearCollection={workspace.clearCollection}
           onCreateCollection={workspace.createCollection}
+          onReorderCollections={workspace.reorderCollections}
+          reorderingCollections={workspace.reorderingCollections}
           onRenameCollection={workspace.renameCollection}
           onDeleteCollection={workspace.deleteCollection}
           onAnnotateCollection={(collectionId) => runAnnotation(null, { scope: "collection", collectionId, onlyMissing: true })}

--- a/apps/desktop/src/api/browser/bridge.js
+++ b/apps/desktop/src/api/browser/bridge.js
@@ -202,7 +202,7 @@ async function ingestFile(file, source = "generated") {
 }
 
 function stageFiles(files) {
-  const images = Array.from(files || []).filter((f) => f.type.startsWith("image/"));
+  const images = Array.from(files || []).filter((f) => f.type.startsWith("image/") && !f.name.startsWith("._") && !(f.webkitRelativePath || "").split("/").includes("__MACOSX"));
   if (!images.length) return null;
   const key = `/web-import/${nextPathId++}`;
   pendingFiles.set(key, images);
@@ -833,7 +833,18 @@ export const browserBridge = {
     return (row.asset_ids || []).map((id) => byId.get(id)).filter(Boolean).slice(offset, offset + limit);
   },
   listCollections: async () => {
-    return collections.map(publicCollection);
+    return [...collections].sort((a, b) => a.sort_order - b.sort_order || a.name.localeCompare(b.name)).map(publicCollection);
+  },
+  reorderCollections: async (collectionIds) => {
+    const manual = collections.filter((c) => c.kind === "manual");
+    if (collectionIds.length !== manual.length || new Set(collectionIds).size !== manual.length ||
+        manual.some((c) => !collectionIds.includes(c.collection_id))) {
+      throw new Error("Folder list changed; reload and try again");
+    }
+    const order = new Map(collectionIds.map((id, index) => [id, index]));
+    for (const row of manual) row.sort_order = order.get(row.collection_id);
+    emitCollectionsChanged();
+    return { ok: true };
   },
   createCollection: async (name, kind = "manual") => {
     const now = new Date().toISOString();
@@ -843,7 +854,7 @@ export const browserBridge = {
       kind: kind || "manual",
       parent_collection_id: null,
       rules_json: null,
-      sort_order: collections.length,
+      sort_order: Math.max(-1, ...collections.map((c) => c.sort_order || 0)) + 1,
       created_at: now,
       updated_at: now,
       asset_ids: [],
@@ -857,6 +868,7 @@ export const browserBridge = {
     const row = collections.find((c) => c.collection_id === collectionId);
     if (!row) return null;
     if (typeof updates.name === "string" && updates.name.trim()) row.name = updates.name.trim();
+    if (Number.isInteger(updates.sortOrder)) row.sort_order = updates.sortOrder;
     row.updated_at = new Date().toISOString();
 
     emitCollectionsChanged();

--- a/apps/desktop/src/api/index.js
+++ b/apps/desktop/src/api/index.js
@@ -90,6 +90,7 @@ const api = {
   startNativeDrag: (...args) => invoke("startNativeDrag", ...args),
 
   // ── collections ──
+  reorderCollections: (...args) => invoke("reorderCollections", ...args),
   listCollections: (...args) => invoke("listCollections", ...args),
   createCollection: (...args) => invoke("createCollection", ...args),
   updateCollection: (...args) => invoke("updateCollection", ...args),

--- a/apps/desktop/src/components/Sidebar.jsx
+++ b/apps/desktop/src/components/Sidebar.jsx
@@ -52,6 +52,8 @@ export default function Sidebar({
   onSelectCollection,
   onClearCollection,
   onCreateCollection,
+  onReorderCollections,
+  reorderingCollections = false,
   onRenameCollection,
   onDeleteCollection,
   onAnnotateCollection,
@@ -113,6 +115,41 @@ export default function Sidebar({
   }, [folderView, coverKey]);
   const [editingId, setEditingId] = useState(null);
   const [dropTargetId, setDropTargetId] = useState(null);
+  const [draggingFolderId, setDraggingFolderId] = useState(null);
+  const [folderInsertion, setFolderInsertion] = useState(null);
+  const folderScrollRef = useRef(null);
+  const folderScrollSpeed = useRef(0);
+  useEffect(() => {
+    if (!draggingFolderId) return undefined;
+    let frame;
+    const scroll = () => {
+      if (folderScrollRef.current) folderScrollRef.current.scrollTop += folderScrollSpeed.current;
+      frame = requestAnimationFrame(scroll);
+    };
+    frame = requestAnimationFrame(scroll);
+    return () => { cancelAnimationFrame(frame); folderScrollSpeed.current = 0; };
+  }, [draggingFolderId]);
+
+  function endFolderDrag() {
+    setDraggingFolderId(null);
+    setFolderInsertion(null);
+    folderScrollSpeed.current = 0;
+  }
+
+  function folderDestination(event, id) {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return { id, after: event.clientY >= rect.top + rect.height / 2 };
+  }
+
+  function moveFolder(sourceId, targetId, after) {
+    if (sourceId === targetId || reorderingCollections) return;
+    const original = manualCollections.map((c) => c.collection_id);
+    if (!original.includes(sourceId) || !original.includes(targetId)) return;
+    const ordered = original.filter((id) => id !== sourceId);
+    ordered.splice(ordered.indexOf(targetId) + (after ? 1 : 0), 0, sourceId);
+    if (ordered.some((id, index) => id !== original[index])) void onReorderCollections?.(ordered);
+  }
+
 
   function readDraggedAssetIds(event) {
     const raw = event.dataTransfer.getData("application/x-media-workspace-asset");
@@ -265,7 +302,20 @@ export default function Sidebar({
           </div>
 
           <div
+            ref={folderScrollRef}
             data-testid="sidebar-folder-scroll"
+            onDragOver={(event) => {
+              if (!draggingFolderId) return;
+              event.preventDefault();
+              const rect = event.currentTarget.getBoundingClientRect();
+              folderScrollSpeed.current = event.clientY < rect.top + 32 ? -7 : event.clientY > rect.bottom - 32 ? 7 : 0;
+            }}
+            onDragLeave={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget)) {
+                folderScrollSpeed.current = 0;
+                setFolderInsertion(null);
+              }
+            }}
             className="min-h-0 flex-1 space-y-0.5 overflow-y-auto overscroll-contain pb-2"
           >
             {creatingFolder && (
@@ -281,7 +331,7 @@ export default function Sidebar({
               </div>
             )}
 
-            {(collections || []).filter((c) => c.kind === "manual").map((col) => {
+            {manualCollections.map((col) => {
               const active = activeCollectionId === col.collection_id;
               if (editingId === col.collection_id) {
                 const editor = (
@@ -326,9 +376,40 @@ export default function Sidebar({
                   key={col.collection_id}
                   role="button"
                   tabIndex={0}
+                  data-collection-id={col.collection_id}
+                  data-folder-insertion={folderInsertion?.id === col.collection_id ? (folderInsertion.after ? "after" : "before") : undefined}
+                  draggable={!reorderingCollections}
+                  title={t("sidebar.reorderHint")}
+                  onDragStart={(event) => {
+                    if (event.target.closest("button, input") || reorderingCollections) {
+                      event.preventDefault();
+                      return;
+                    }
+                    event.dataTransfer.setData("application/x-afterframe-folder", col.collection_id);
+                    event.dataTransfer.effectAllowed = "move";
+                    setDropTargetId(null);
+                    setDraggingFolderId(col.collection_id);
+                  }}
+                  onDragEnd={endFolderDrag}
                   onClick={() => onSelectCollection?.(col.collection_id)}
-                  onKeyDown={(e) => { if (e.key === "Enter") onSelectCollection?.(col.collection_id); }}
+                  onKeyDown={(event) => {
+                    if (event.target !== event.currentTarget) return;
+                    if (event.key === "Enter") onSelectCollection?.(col.collection_id);
+                    if (event.altKey && ["ArrowUp", "ArrowDown"].includes(event.key)) {
+                      event.preventDefault();
+                      const index = manualCollections.findIndex((c) => c.collection_id === col.collection_id);
+                      const after = event.key === "ArrowDown";
+                      const neighbor = manualCollections[index + (after ? 1 : -1)];
+                      if (neighbor) moveFolder(col.collection_id, neighbor.collection_id, after);
+                    }
+                  }}
                   onDragOver={(event) => {
+                    if (draggingFolderId) {
+                      event.preventDefault();
+                      event.dataTransfer.dropEffect = "move";
+                      setFolderInsertion(draggingFolderId === col.collection_id ? null : folderDestination(event, col.collection_id));
+                      return;
+                    }
                     if (!readDraggedAssetIds(event).length) return;
                     event.preventDefault();
                     event.dataTransfer.dropEffect = "copy";
@@ -337,16 +418,26 @@ export default function Sidebar({
                     }
                   }}
                   onDragEnter={(event) => {
+                    if (draggingFolderId) { event.preventDefault(); return; }
                     if (!readDraggedAssetIds(event).length) return;
                     event.preventDefault();
                     setDropTargetId(col.collection_id);
                   }}
                   onDragLeave={(event) => {
                     if (!event.currentTarget.contains(event.relatedTarget)) {
+                      setFolderInsertion((current) => current?.id === col.collection_id ? null : current);
                       setDropTargetId((current) => (current === col.collection_id ? null : current));
                     }
                   }}
                   onDrop={async (event) => {
+                    if (draggingFolderId) {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      const destination = folderDestination(event, col.collection_id);
+                      moveFolder(draggingFolderId, destination.id, destination.after);
+                      endFolderDrag();
+                      return;
+                    }
                     const assetIds = readDraggedAssetIds(event);
                     event.preventDefault();
                     setDropTargetId(null);
@@ -356,9 +447,10 @@ export default function Sidebar({
                     await onAddToCollection?.(col.collection_id, assetIds);
                   }}
                   className={[
-                    "group flex w-full cursor-pointer items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors",
+                    "sidebar-folder-row group relative flex w-full cursor-pointer items-center justify-between rounded-md px-2.5 py-1.5 text-left transition-colors",
+                    draggingFolderId === col.collection_id ? "opacity-50" : "",
                     dropTargetId === col.collection_id && !active
-                      ? "bg-hover text-text ring-1 ring-accent/45"
+                      ? "bg-hover text-text ring-1 ring-inset ring-accent/45"
                       : "",
                     active
                       ? "bg-selected text-text"

--- a/apps/desktop/src/hooks/useWorkspace.js
+++ b/apps/desktop/src/hooks/useWorkspace.js
@@ -395,6 +395,28 @@ export default function useWorkspace({ pushToast } = {}) {
     return col;
   }
 
+  const reorderingCollectionsRef = useRef(false);
+  const [reorderingCollections, setReorderingCollections] = useState(false);
+  async function reorderCollections(collectionIds) {
+    if (reorderingCollectionsRef.current) return;
+    reorderingCollectionsRef.current = true;
+    setReorderingCollections(true);
+    const byId = new Map(collections.map((c) => [c.collection_id, c]));
+    setCollections([
+      ...collectionIds.map((id, sort_order) => ({ ...byId.get(id), sort_order })),
+      ...collections.filter((c) => c.kind !== "manual"),
+    ]);
+    try {
+      await api.reorderCollections(collectionIds);
+    } catch (error) {
+      pushToast?.({ title: t("folderOrderFailed"), message: String(error?.message || error), tone: "error" });
+    } finally {
+      await loadCollections();
+      reorderingCollectionsRef.current = false;
+      setReorderingCollections(false);
+    }
+  }
+
   async function renameCollection(collectionId, name) {
     await api.updateCollection(collectionId, { name });
     await loadCollections();
@@ -915,6 +937,8 @@ export default function useWorkspace({ pushToast } = {}) {
     browseTo,
     setStatusFilter,
     createCollection,
+    reorderCollections,
+    reorderingCollections,
     renameCollection,
     deleteCollection,
     addToCollection,

--- a/apps/desktop/src/i18n/locales/en/app.json
+++ b/apps/desktop/src/i18n/locales/en/app.json
@@ -1,4 +1,5 @@
 {
+  "folderOrderFailed": "Could not save folder order",
   "drop": {
     "title": "Drop to import",
     "subtitle": "Files and folders will be added to the catalog"

--- a/apps/desktop/src/i18n/locales/en/nav.json
+++ b/apps/desktop/src/i18n/locales/en/nav.json
@@ -59,6 +59,7 @@
     "navigation": "Discover sections"
   },
   "sidebar": {
+    "reorderHint": "Drag to reorder · Option/Alt + ↑/↓",
     "discover": "Discover",
     "people": "People",
     "stickers": "Stickers",

--- a/apps/desktop/src/i18n/locales/zh-CN/app.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/app.json
@@ -1,4 +1,5 @@
 {
+  "folderOrderFailed": "无法保存文件夹顺序",
   "drop": {
     "title": "拖放以导入",
     "subtitle": "文件和文件夹将被添加到图库"

--- a/apps/desktop/src/i18n/locales/zh-CN/nav.json
+++ b/apps/desktop/src/i18n/locales/zh-CN/nav.json
@@ -59,6 +59,7 @@
     "navigation": "发现页导航"
   },
   "sidebar": {
+    "reorderHint": "拖拽排序 · Option/Alt + ↑/↓",
     "discover": "发现",
     "people": "人物",
     "stickers": "贴纸",

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -858,3 +858,17 @@ html.electron .discover-drag-region { pointer-events: auto; -webkit-app-region: 
 .collage-ratio-input { height: 24px; border: 0; border-radius: 999px; background: var(--fill); outline: none; box-shadow: none; transition: background .15s; }
 .collage-ratio-input:hover { background: var(--fill-2); }
 .collage-ratio-input:focus-visible { background: var(--fill-2); outline: 2px solid rgb(var(--text-color) / .35); outline-offset: 2px; }
+
+/* Inset insertion markers remain visible inside the folder scroll viewport. */
+.sidebar-folder-row[data-folder-insertion]::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgb(var(--accent-color) / .8);
+  pointer-events: none;
+}
+.sidebar-folder-row[data-folder-insertion="before"]::after { top: 0; }
+.sidebar-folder-row[data-folder-insertion="after"]::after { bottom: 0; }

--- a/services/sidecar/src/media_workspace/cli.py
+++ b/services/sidecar/src/media_workspace/cli.py
@@ -54,6 +54,7 @@ from .db import (
     summary,
     upsert_catalog_root,
     list_collections,
+    reorder_collections,
     create_collection,
     update_collection,
     delete_collection,
@@ -332,6 +333,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     # Collections
     subparsers.add_parser("list-collections", parents=[common])
+
+    reorder_col = subparsers.add_parser("reorder-collections", parents=[common])
+    reorder_col.add_argument("--collection-id", action="append", required=True)
 
     create_col = subparsers.add_parser("create-collection", parents=[common])
     create_col.add_argument("--name", required=True)
@@ -1965,6 +1969,12 @@ def _cmd_list_collections(args, connection, catalog, parser):
     return 0
 
 
+def _cmd_reorder_collections(args, connection, catalog, parser):
+    reorder_collections(connection, args.collection_id)
+    print(json.dumps({"ok": True}))
+    return 0
+
+
 def _cmd_create_collection(args, connection, catalog, parser):
     col = create_collection(connection, args.name, args.kind, args.rules_json)
     print(json.dumps(col, indent=2))
@@ -2129,6 +2139,7 @@ COMMAND_HANDLERS = {
     "summary": _cmd_summary,
     "scan-new-media": _cmd_scan_new_media,
     "list-collections": _cmd_list_collections,
+    "reorder-collections": _cmd_reorder_collections,
     "create-collection": _cmd_create_collection,
     "update-collection": _cmd_update_collection,
     "delete-collection": _cmd_delete_collection,

--- a/services/sidecar/src/media_workspace/db/__init__.py
+++ b/services/sidecar/src/media_workspace/db/__init__.py
@@ -9,7 +9,7 @@ from .browse import list_version_siblings, _browse_order_clause, _facet_clauses,
 from .locations import upsert_asset_location_from_metadata, upsert_ai_asset_location, delete_asset_location, list_map_points, set_manual_asset_location, get_asset_location
 from .jobs import _job_id, _decode_job_row, create_job, update_job, get_job, get_latest_job, list_jobs, list_active_jobs, request_job_cancel, is_cancel_requested, request_job_pause, request_job_resume, is_pause_requested
 from .people import upsert_face_model, get_people_asset_index, upsert_people_asset_index, replace_asset_faces, list_asset_faces, list_people_index_candidates, rebuild_candidate_groups, list_person_groups, list_similar_person_groups, get_asset_people, get_person_group_detail, set_person_group_name, set_person_group_cover, set_person_group_state, set_person_groups_state, merge_person_groups, remove_face_from_group, assign_face_to_group, remove_faces_from_group, assign_faces_to_group
-from .collections import _collection_id, list_collections, create_collection, update_collection, delete_collection, add_collection_items, remove_collection_items
+from .collections import _collection_id, list_collections, reorder_collections, create_collection, update_collection, delete_collection, add_collection_items, remove_collection_items
 from .maintenance import cleanup_orphan_image_assets, delete_image_asset_from_catalog, summary, verify_assets, relink_asset
 from .jobs import _UNSET  # sentinel shared with update_job callers
 from .core import _file_id, RESOLVER_VERSION

--- a/services/sidecar/src/media_workspace/db/collections.py
+++ b/services/sidecar/src/media_workspace/db/collections.py
@@ -35,8 +35,8 @@ def create_collection(
     collection_id = _collection_id()
     connection.execute(
         """
-        INSERT INTO collections (collection_id, name, kind, rules_json)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO collections (collection_id, name, kind, rules_json, sort_order)
+        VALUES (?, ?, ?, ?, (SELECT COALESCE(MAX(sort_order), -1) + 1 FROM collections))
         """,
         (collection_id, name, kind, rules_json),
     )
@@ -74,6 +74,21 @@ def update_collection(
     )
     if commit:
         connection.commit()
+
+
+def reorder_collections(connection: sqlite3.Connection, collection_ids: list[str]) -> None:
+    """Save the complete manual-folder order atomically; reject stale lists."""
+    with connection:
+        connection.execute("BEGIN IMMEDIATE")
+        current = {r[0] for r in connection.execute(
+            "SELECT collection_id FROM collections WHERE kind = 'manual'"
+        )}
+        if len(collection_ids) != len(current) or set(collection_ids) != current:
+            raise ValueError("Folder list changed; reload and try again")
+        connection.executemany(
+            "UPDATE collections SET sort_order = ?, updated_at = CURRENT_TIMESTAMP WHERE collection_id = ?",
+            [(index, collection_id) for index, collection_id in enumerate(collection_ids)],
+        )
 
 
 def delete_collection(connection: sqlite3.Connection, collection_id: str, commit: bool = True) -> None:

--- a/services/sidecar/src/media_workspace/file_types.py
+++ b/services/sidecar/src/media_workspace/file_types.py
@@ -23,6 +23,11 @@ RAW_EXTENSION_FORMATS = {
 }
 
 
+def is_macos_metadata(path: Path) -> bool:
+    """AppleDouble companions keep the original extension but contain no image."""
+    return path.name.startswith("._") or "__MACOSX" in path.parts
+
+
 def _read_signature(path: Path, limit: int = RAW_SIGNATURE_SAMPLE_BYTES) -> bytes:
     with path.open("rb") as handle:
         return handle.read(limit)
@@ -69,6 +74,8 @@ def _detect_tiff_raw_format(data: bytes) -> str | None:
 
 
 def detect_raw_format(path: Path) -> str | None:
+    if is_macos_metadata(path):
+        return None
     extension = path.suffix.lower()
     if extension in DEFAULT_RAW_EXTENSIONS:
         return RAW_EXTENSION_FORMATS.get(extension, extension.lstrip("."))
@@ -82,4 +89,4 @@ def is_raw_file(path: Path) -> bool:
 
 
 def is_source_file(path: Path) -> bool:
-    return is_raw_file(path) or path.suffix.lower() in DEFAULT_IMAGE_EXTENSIONS
+    return not is_macos_metadata(path) and (is_raw_file(path) or path.suffix.lower() in DEFAULT_IMAGE_EXTENSIONS)

--- a/services/sidecar/src/media_workspace/reverse_lookup.py
+++ b/services/sidecar/src/media_workspace/reverse_lookup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from sqlite3 import Row
 
 from .config import DEFAULT_RAW_EXTENSIONS, Thresholds
+from .file_types import is_macos_metadata
 from .db import (
     get_registry,
     load_raw_cache,
@@ -563,12 +564,14 @@ MEDIA_EXTENSIONS = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS | DEFAULT_RAW_EXTENSIONS
 def iter_image_files(image_paths: list[Path]):
     for image_path in image_paths:
         image_path = image_path.resolve()
+        if is_macos_metadata(image_path):
+            continue
         if image_path.is_file():
             if image_path.suffix.lower() in MEDIA_EXTENSIONS:
                 yield image_path
             continue
         for path in sorted(image_path.rglob("*")):
-            if path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS:
+            if not is_macos_metadata(path) and path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS:
                 yield path
 
 

--- a/services/sidecar/src/media_workspace/watcher.py
+++ b/services/sidecar/src/media_workspace/watcher.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from .config import DEFAULT_IMAGE_EXTENSIONS, Thresholds
 from .reverse_lookup import resolve_image
+from .file_types import is_macos_metadata
 
 
 class ImageWatcher:
@@ -27,7 +28,7 @@ class ImageWatcher:
             if not image_dir.exists():
                 continue
             for path in sorted(image_dir.rglob("*")):
-                if not path.is_file() or path.suffix.lower() not in DEFAULT_IMAGE_EXTENSIONS:
+                if is_macos_metadata(path) or not path.is_file() or path.suffix.lower() not in DEFAULT_IMAGE_EXTENSIONS:
                     continue
                 stat = path.stat()
                 key = str(path.resolve())

--- a/tests/test_collection_order.py
+++ b/tests/test_collection_order.py
@@ -1,0 +1,36 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from media_workspace.db import connect, init_db
+from media_workspace.db.collections import create_collection, list_collections, reorder_collections
+
+
+class CollectionOrderTests(unittest.TestCase):
+    def test_order_persists_and_new_folders_append(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'catalog.sqlite'
+            connection = connect(path)
+            init_db(connection)
+            ids = [create_collection(connection, name)['collection_id'] for name in ['Zulu', 'Alpha', 'Middle']]
+            reorder_collections(connection, [ids[2], ids[0], ids[1]])
+            connection.close()
+            connection = connect(path)
+            self.addCleanup(connection.close)
+            new_id = create_collection(connection, 'A new folder')['collection_id']
+            self.assertEqual([row['collection_id'] for row in list_collections(connection)], [ids[2], ids[0], ids[1], new_id])
+
+    def test_stale_or_duplicate_order_leaves_existing_order_intact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            connection = connect(Path(directory) / 'catalog.sqlite')
+            self.addCleanup(connection.close)
+            init_db(connection)
+            ids = [create_collection(connection, name)['collection_id'] for name in ['B', 'A']]
+            smart = create_collection(connection, 'Smart', 'smart')['collection_id']
+            before = list_collections(connection)
+            for invalid in ([ids[0]], [ids[0], ids[0]], [ids[1], 'missing'], [ids[0], smart]):
+                with self.assertRaises(ValueError):
+                    reorder_collections(connection, invalid)
+                self.assertEqual(list_collections(connection), before)
+            reorder_collections(connection, list(reversed(ids)))
+            self.assertEqual([row['collection_id'] for row in list_collections(connection) if row['kind'] == 'manual'], list(reversed(ids)))

--- a/tests/test_macos_metadata.py
+++ b/tests/test_macos_metadata.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from media_workspace.file_types import is_raw_file, is_source_file
+from media_workspace.reverse_lookup import iter_image_files
+from media_workspace.scanner import scan_raw_directory
+from media_workspace.catalog import ensure_catalog
+from media_workspace.db import connect, init_db
+
+
+class MacMetadataTests(unittest.TestCase):
+    def test_folder_and_direct_import_ignore_companions_but_keep_real_hidden_images(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            names = ['portrait.png', '._portrait.png', 'raw.CR3', '._raw.CR3', '.hidden.png', '__MACOSX/copy.png']
+            for name in names:
+                path = root / name
+                path.parent.mkdir(exist_ok=True)
+                path.write_bytes(b'\x00\x05\x16\x07' + b'\x00' * 20)
+            expected = {root / name for name in ['portrait.png', 'raw.CR3', '.hidden.png']}
+            self.assertEqual(set(iter_image_files([root])), expected)
+            self.assertEqual(set(iter_image_files([root / name for name in names])), expected)
+            self.assertFalse(is_raw_file(root / '._raw.CR3'))
+            self.assertFalse(is_source_file(root / '._portrait.png'))
+
+    def test_raw_scan_does_not_index_appledouble_raws(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            raw = root / 'raw'
+            raw.mkdir()
+            (raw / 'photo.CR3').write_bytes(b'raw-placeholder')
+            (raw / '._photo.CR3').write_bytes(b'\x00\x05\x16\x07' + b'\x00' * 4092)
+            catalog = ensure_catalog(root / 'demo.afcatalog')
+            connection = connect(catalog.db_path)
+            self.addCleanup(connection.close)
+            init_db(connection)
+            result = scan_raw_directory(connection, raw, workers=1)
+            self.assertEqual(result['indexed'], 1)


### PR DESCRIPTION
Add manual drag ordering to sidebar folders and prevent macOS metadata companions from appearing as photos with missing previews.

- Drag folder rows to reorder in list or cover view, with insertion markers, edge scrolling, and Option/Alt + arrow keyboard controls. Persist the complete order atomically in desktop catalogs; preserve session-only behavior in the browser. New folders append to the end.
- Keep photo drops separate from folder reordering and draw their highlight inside the row so the scroll container does not clip it.
- Exclude AppleDouble `._` files and `__MACOSX` contents from image imports, RAW classification, watched imports, and browser imports. Existing catalog entries and original files are untouched.
- Add desktop/browser regression coverage and include the folder-order suite in GitHub CI.

Validation: desktop lint, unit tests, and build passed; Python suite passed (77 tests); desktop and browser folder-order E2E passed, including persistence, cancellation, and photo membership; browser metadata-filter E2E passed. Read-only validation of the reported source directory now finds 267 real photos instead of 534 image-suffixed files.
